### PR TITLE
Return user IDs on /accounts GET, force user email's to be unique

### DIFF
--- a/src/main/java/perkpack/models/Account.java
+++ b/src/main/java/perkpack/models/Account.java
@@ -12,20 +12,20 @@ import java.util.*;
 
 @Entity
 public class Account {
-
     public static final PasswordEncoder PASSWORD_ENCODER = new BCryptPasswordEncoder();
 
     @NotNull
-    @Size(min =1, max = 32)
+    @Size(min = 1, max = 32)
     private String firstName;
 
     @NotNull
-    @Size(min =1, max = 32)
+    @Size(min = 1, max = 32)
     private String lastName;
 
     @NotNull
     @Email
-    @Size(min =1, max = 32)
+    @Column(unique = true)
+    @Size(min = 1, max = 32)
     private String email;
 
     @NotNull

--- a/src/main/java/perkpack/repositories/AccountExposeIdRepositoryConfiguration.java
+++ b/src/main/java/perkpack/repositories/AccountExposeIdRepositoryConfiguration.java
@@ -1,0 +1,15 @@
+package perkpack.repositories;
+
+import org.springframework.data.rest.core.config.RepositoryRestConfiguration;
+import org.springframework.data.rest.webmvc.config.RepositoryRestConfigurerAdapter;
+import org.springframework.stereotype.Component;
+import perkpack.models.Account;
+
+@Component
+public class AccountExposeIdRepositoryConfiguration extends RepositoryRestConfigurerAdapter {
+
+    @Override
+    public void configureRepositoryRestConfiguration(RepositoryRestConfiguration config) {
+        config.exposeIdsFor(Account.class);
+    }
+}

--- a/src/main/java/perkpack/repositories/AccountRepository.java
+++ b/src/main/java/perkpack/repositories/AccountRepository.java
@@ -1,9 +1,9 @@
 package perkpack.repositories;
 
+import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.data.repository.query.Param;
 import perkpack.models.Account;
-import org.springframework.data.repository.CrudRepository;
 
-public interface AccountRepository extends CrudRepository<Account, Long> {
+public interface AccountRepository extends PagingAndSortingRepository<Account, Long> {
     Account findByEmail(@Param("email") String email);
 }

--- a/src/main/java/perkpack/repositories/PerkVoteRepository.java
+++ b/src/main/java/perkpack/repositories/PerkVoteRepository.java
@@ -1,7 +1,7 @@
 package perkpack.repositories;
 
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.PagingAndSortingRepository;
 import perkpack.models.PerkVote;
 
-public interface PerkVoteRepository extends CrudRepository<PerkVote,Long> {
+public interface PerkVoteRepository extends PagingAndSortingRepository<PerkVote,Long> {
 }

--- a/src/test/java/perkpack/controllers/AccountRestControllerTest.java
+++ b/src/test/java/perkpack/controllers/AccountRestControllerTest.java
@@ -169,7 +169,7 @@ public class AccountRestControllerTest {
     @Test
     public void getValidUserTest() throws Exception
     {
-        Account account = new Account("Ali", "Farah", "a@gmail.com","password");
+        Account account = new Account("Ali", "Farah", "b@gmail.com","password");
         Account createAccount = accountRepository.save(account);
 
         mockMvc.perform(get("/account/" + createAccount.getId())).

--- a/src/test/java/perkpack/controllers/CardRestControllerTest.java
+++ b/src/test/java/perkpack/controllers/CardRestControllerTest.java
@@ -88,8 +88,10 @@ public class CardRestControllerTest {
     @After
     public void tearDown()
     {
+        accountRepository.delete(user);
         perkRepository.delete(perk);
         categoryRepository.delete(games);
+        cardRepository.delete(card);
     }
 
     @Test
@@ -124,6 +126,7 @@ public class CardRestControllerTest {
                 andExpect(jsonPath("$.name", is(newName))).
                 andExpect(jsonPath("$.description", is(newDescription)));
     }
+
     @Test
     @WithMockUser(username = "lava@gmail.com", password = "password")
     public void addPerkToCardTest() throws Exception
@@ -132,6 +135,7 @@ public class CardRestControllerTest {
                 andExpect(status().isOk()).
                 andExpect(jsonPath("$.perks[0].name", is(perk.getName())));
     }
+
     @Test
     @WithMockUser(username = "lava@gmail.com", password = "password")
     public void removePerkFromCardTest() throws Exception
@@ -142,16 +146,24 @@ public class CardRestControllerTest {
                 andExpect(status().isOk()).
                 andExpect(jsonPath("$.perks", hasSize(0)));
     }
+
     @Test
     @WithMockUser(username = "ali@gmail.com", password = "password")
     public void addUserToCardTest() throws Exception
     {
         user2 = new Account("Ali", "Farah", "ali@gmail.com", "password");
         user2 = accountRepository.save(user2);
-        mockMvc.perform(patch("/cards/"+card.getId() + "/addUser")).
+        mockMvc.perform(patch("/cards/" + card.getId() + "/addUser")).
                 andExpect(status().isOk()).
                 andExpect(jsonPath("$.accounts[0].firstName", is(user2.getFirstName())));
+
+        mockMvc.perform(patch("/cards/" + card.getId() + "/removeUser/")).
+                andExpect(status().isOk()).
+                andExpect(jsonPath("$.accounts", hasSize(0)));
+
+        accountRepository.delete(user2);
     }
+
     @Test
     @WithMockUser(username = "guy@gmail.com", password = "password")
     public void removeUserFromCardTest() throws Exception
@@ -163,5 +175,7 @@ public class CardRestControllerTest {
         mockMvc.perform(patch("/cards/"+card.getId() + "/removeUser/")).
                 andExpect(status().isOk()).
                 andExpect(jsonPath("$.accounts", hasSize(0)));
+
+        accountRepository.delete(user3);
     }
 }


### PR DESCRIPTION
- When the /accounts REST endpoint is queried, each entry also returns the ID.
- Account emails must be unique now, preventing the same email from registering twice (this doesn't take effect until the Account table is dropped and recreated, so I'll have to do that once this is merged)
- Fix some problems in tests

Fixes issue #56 